### PR TITLE
Fix announcement bar scroll

### DIFF
--- a/src/css/components/_driver.css
+++ b/src/css/components/_driver.css
@@ -15,17 +15,26 @@
 }
 
 .driver__title {
+  width: calc(100% - 16px); /* accommodate icon beside it*/
   margin-right: var(--space-1);
   margin-bottom: 0;
+  overflow: hidden;
   font-size: var(--font-scale-6);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .driver__excerpt {
+  display: -webkit-box;
+  overflow: hidden;
   transition: color var(--transition-time-fast);
   font-size: var(--font-scale-8);
   font-weight: 600;
   letter-spacing: var(--track);
   line-height: var(--line-height-snug);
+
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .driver__a:hover .driver__excerpt {

--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -21,7 +21,7 @@ header.header,
   height: var(--announcement-bar-height);
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
-  overflow-y: scroll;
+  overflow-y: auto;
   background: var(--anakiwa);
   -webkit-overflow-scrolling: touch;
 }

--- a/src/modules/layout/header-nav.module/module.css
+++ b/src/modules/layout/header-nav.module/module.css
@@ -14,9 +14,13 @@
 }
 
 @media (min-width: 960px) {
-  .header-logo,
-  .header-utils {
+  .header-logo {
     flex: 0 0 12.5rem;
+  }
+
+  .header-utils {
+    flex: 0 0 auto;
+    width: 12.5rem;
   }
 
   .header-quick-nav,


### PR DESCRIPTION
## Description
This PR hides the scrollbar track on the announcement bar. On macOS settings, where "Show scroll bars" is set to "Always", the scrollbar track is always visible regardless of the need to scroll.

## Screenshots

Before:

![Screenshot 2023-05-25 at 19 48 55](https://github.com/dariusbaker/core-clinic-2023-hubspot/assets/19809585/48ef95eb-8ed5-43c1-82c8-f8ef9827d015)

After:

![Screenshot 2023-05-25 at 19 49 45](https://github.com/dariusbaker/core-clinic-2023-hubspot/assets/19809585/70d9326f-3696-46bc-b4f1-f4ab5f821ce2)

