### PR TITLE
Fix border radius var typo on location images

### DIFF
--- a/src/modules/articles/location-article.module/module.css
+++ b/src/modules/articles/location-article.module/module.css
@@ -31,7 +31,7 @@
   height: 0;
   padding-bottom: 100%;
   overflow: hidden;
-  border-radius: var(--border-radiu_subs-3);
+  border-radius: var(--border-radius-3);
 }
 
 .location-article__thumb-wrap--1 {


### PR DESCRIPTION
## Description
This PR fixes a var typo that causes the border radius on location article images to not render.

## Screenshots
N/A